### PR TITLE
Added better support for whitespace/multi-line lists and multiple config files.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,5 +26,6 @@ parseconf("sample.conf")
 @test conf["vals"][1] == "one"
 @test conf["vals"][2] == 2
 @test conf["vals"][3] == "three"
+@test conf["white.space"] == ["Hi", 42, "Hello", 111]
 
 @show conf

--- a/test/sample.conf
+++ b/test/sample.conf
@@ -9,3 +9,9 @@ bool=false
 ip=192.168.31.12
 arr=[foo,"bar" ,baz,7]
 vals=["one", 2, three]
+
+# Support white space
+white.space = [ "Hi",
+42
+,
+    "Hello", 111]


### PR DESCRIPTION
- `parseconf` now returns the dictionary it parses, as well as assigning the global `conf` variable
- Can now parse multi-line lists
- strips white-space before the `=` character
- `String => AbstractString` throughout

I extended the tests to parse a multi-line list, with a space before the equals sign.
