### PR TITLE
Fix package on 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/src/AppConf.jl
+++ b/src/AppConf.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+isdefined(Base, :__precompile__) && __precompile__(true)
 
 module AppConf
 


### PR DESCRIPTION
by checking for the existence of `__precompile__` before using it

and restore testing on travis

The most recent tag https://github.com/JuliaLang/METADATA.jl/pull/4212 broke the package for any users still on julia 0.3. If you had changed the minimum version in `REQUIRE` to `julia 0.4`, then 0.3 users would stay on the previous tag and only julia 0.4-or-newer users would see the new tag.

In this case it's an easy fix, so either you can merge and tag this, or we need to modify the requirements of the latest tag in METADATA, and the version in the `REQUIRE` file here to properly drop support for julia 0.3 in future package versions.
