### PR TITLE
Unicodesupport

### DIFF
--- a/src/AppConf.jl
+++ b/src/AppConf.jl
@@ -98,7 +98,9 @@ function parseconf(file::AbstractString)
 
   f = open(file)
   inquotes = false
-  conf = Dict{AbstractString, Any}()
+    if !isdefined(:conf)
+        conf = Dict{AbstractString, Any}()
+    end
   while !eof(f)
     ln = evalEnv(stripcomments(readline(f)))
     ix = findeq(ln)

--- a/src/AppConf.jl
+++ b/src/AppConf.jl
@@ -80,9 +80,16 @@ function isnumeric(str::AbstractString)
 end
 
 islist(str::AbstractString) = str[1] == '[' && str[length(str)] == ']'
+istuple(str::AbstractString) = str[1] == '(' && str[length(str)] == ')'
 
 parselist(str::AbstractString) = map((x) -> isnumeric(x) ? parse(x) : cleanstring(x),
     split(match(r"\[(.*)\]", str).captures[1], ","))
+
+function parsetuple(str::AbstractString)
+    res = map((x) -> isnumeric(x) ? parse(x) : cleanstring(x),
+        split(match(r"\((.*)\)", str).captures[1], ","))
+    return ntuple((i) -> res[i], length(res))
+end
 
 function parseconf(file::AbstractString)
   file = abspath(file)
@@ -114,6 +121,9 @@ function parseconf(file::AbstractString)
     # Handle single-line lists
     elseif islist(val)
       conf[key] = parselist(val)
+    # Handle single-line lists
+    elseif istuple(val)
+      conf[key] = parsetuple(val)
     # Parse multi-line lists
     elseif val[1] == '['
       # Base case: first line

--- a/src/AppConf.jl
+++ b/src/AppConf.jl
@@ -28,12 +28,13 @@ macro prod(e)
 end
 
 function findeq(ln::AbstractString)
-  for i = 1:length(ln)
-    if ln[i] == '='
-      return i
+    for i = 1:length(ln)
+        c = chr2ind(ln, i);
+        if ln[c] == '='
+            return c
+        end
     end
-  end
-  return -1
+    return -1
 end
 
 function stripcomments(ln::AbstractString)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,12 @@ parseconf("sample.conf")
 @test conf["vals"][1] == "one"
 @test conf["vals"][2] == 2
 @test conf["vals"][3] == "three"
+
+#tuples
+@test conf["tvals"][1] == "one"
+@test conf["tvals"][2] == 2
+@test conf["tvals"][3] == "three"
+
 @test conf["white.space"] == ["Hi", 42, "Hello", 111]
 
 @test conf["var"] == "foo/bar"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ parseconf("sample.conf")
 @test conf["white.space"] == ["Hi", 42, "Hello", 111]
 
 @test conf["var"] == "foo/bar"
+@test conf["ρ"] == 4
+@test conf["γ"] == 1.667
+@test conf["V₁"] == 3
 
 @test parseconf("foo.conf")["template"] == true
 

--- a/test/sample.conf
+++ b/test/sample.conf
@@ -9,6 +9,9 @@ bool=false
 ip=192.168.31.12
 arr=[foo,"bar" ,baz,7]
 vals=["one", 2, three]
+ρ=4
+γ = 1.667
+V₁=3
 
 # Support white space
 white.space = [ "Hi",

--- a/test/sample.conf
+++ b/test/sample.conf
@@ -9,6 +9,8 @@ bool=false
 ip=192.168.31.12
 arr=[foo,"bar" ,baz,7]
 vals=["one", 2, three]
+                                                                                           tvals=("one", 2, three)
+											    
 ρ=4
 γ = 1.667
 V₁=3


### PR DESCRIPTION
As promised in the issue. Here is a pull request to enable unicode characters in the config files.
There may be more places but so far this works well. 
I also added three tests in the example file and make sure they are tested in runtests.jl

Two more useful changes added. Our conf dictionary is only redefined if it does not already exist, allowing one to parse different .conf files and continue populating the same dictionary. 

And one more feature is to include support for "(" parenthesis defining tuples so that "a = (3, 4,5)" in 
a config file will lead dictionary entry to be a tuple vs arrays for "a = [3, 4, 5]". 
