### PR TITLE
Support Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.7
 Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using AppConf, Base.Test
+using AppConf, Test
 
 @dev x = "dev"
 @prod x = "prod"
@@ -42,4 +42,4 @@ parseconf("sample.conf")
 
 @test parseconf("foo.conf")["template"] == true
 
-@test_throws ErrorException parseconf("bar.conf")
+@test_throws SystemError parseconf("bar.conf")


### PR DESCRIPTION
This commit implements the latest syntax for Julia 0.7, and so might break on Julia 0.6 and before. If needs be, `Compat` can be used to assist in backward compatibility, or alternatively just break support for earlier Julia versions.

Changelog:-
- Update `isdefined` to include the containing module, which is compulsory.
- Replace the depreciated `matchall` with an implementation using `eachmatch`.
- Replace the depreciated `chr2ind` with an implementation using `eachindex`.
Instead of doing index arithmetic on Unicode string which give incorrect result, use `prevind` and `nextind`.
- Replace the depreciated `takebuf_string(s)` with a `String(take!(s))` call.
- Replace `Base.Test` with `Test`.
- Update `replace` to use a pair to indicate the replacement.
- Update `parse` of integer string to state the compulsory type to map to. For now, all numeric are assumed to be `Float64` as further casting to specific integer types can be done from there. Similarly, casting to boolean is specified accordingly.
- Replace `parse` with `Meta.parse` when parsing code strings.
- Use logging functions `@warn` and `@error`. `warn` has been depreciated for `@warn`, and to standardise the logging we use `@error` too. This result in a `SystemError` thrown instead of an `ErrorException`.
- Update REQUIRE to use Julia 0.7.